### PR TITLE
Simplified implementation of tokeniseCommandLine 

### DIFF
--- a/src/de/relaunch64/popelganda/util/Tools.java
+++ b/src/de/relaunch64/popelganda/util/Tools.java
@@ -499,6 +499,7 @@ public class Tools {
                 
                 token = new StringBuilder();
                 token.append(character);
+                flags = NONE;
                 continue;
             }
 
@@ -541,7 +542,6 @@ public class Tools {
                     // end of token
                     tokens.add(token.toString());
                     token = null;
-                    flags = NONE;
                     continue;
                 }
             }


### PR DESCRIPTION
Using the token pointer itself to signify whether or not we are
between tokens allows the compiler to predict whether or not it
could be used before it is initialised.

One other minor change is that an unsupported escape sequence
(such as \n) will be stripped entirely rather than reduced to
the non escape character (n).